### PR TITLE
CMR-9856: Bumping up python version

### DIFF
--- a/serverless-local.yml
+++ b/serverless-local.yml
@@ -4,7 +4,7 @@ frameworkVersion: '2 || 3'
 
 provider:
   name: aws
-  runtime: python3.8
+  runtime: python3.10
   memorySize: 128 # default was 1024, 512 would also be accepted
   timeout: 15  # 7 seconds is the average run time currently
   region: us-east-1

--- a/serverless-sandbox.yml
+++ b/serverless-sandbox.yml
@@ -6,7 +6,7 @@ variablesResolutionMode: 20210326
 
 provider:
   name: aws
-  runtime: python3.8
+  runtime: python3.10
   memorySize: 128 # default was 1024, 512 would also be accepted
   timeout: 15  # 7 seconds is the average run time currently
   region: us-east-1

--- a/serverless.yml
+++ b/serverless.yml
@@ -6,7 +6,7 @@ variablesResolutionMode: 20210326
 
 provider:
   name: aws
-  runtime: python3.8
+  runtime: python3.9
   memorySize: 128 # default was 1024, 512 would also be accepted
   region: us-east-1
   role: IamRoleTeaLambdaExecution

--- a/serverless.yml
+++ b/serverless.yml
@@ -6,7 +6,7 @@ variablesResolutionMode: 20210326
 
 provider:
   name: aws
-  runtime: python3.9
+  runtime: python3.10
   memorySize: 128 # default was 1024, 512 would also be accepted
   region: us-east-1
   role: IamRoleTeaLambdaExecution


### PR DESCRIPTION
Bumping up python to a version with a working ssl lib, but also go one more version so we have more time covered by support. This turns out to be version 3.10 (9 works, but lets go forward).