### PR TITLE
MMT-2929: node 16 is to old, going to 18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16
+FROM node:18
 
 RUN apt-get update && \
     apt install -y \


### PR DESCRIPTION
As the title says, node 16 is to old for running serverless, bumping up to 18.