### PR TITLE
MMT-2929: downgrading serverless to the free version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && \
 
 WORKDIR /build
 
-RUN npm install -g serverless
+RUN npm install -g serverless@3
 RUN pip3 install --break-system-packages pylint
 RUN pip3 install --break-system-packages coverage
 RUN pip3 install --break-system-packages pytest

--- a/harbor.sh
+++ b/harbor.sh
@@ -46,7 +46,7 @@ help_doc()
   printf "${format}" '-R' '' 'run' 'Run bash in Docker Image'
 }
 
-while getopts 'hcCbrR' opt; do
+while getopts 'hcCbrRd:' opt; do
   case ${opt} in
     h) help_doc ;;
     c) color_mode='yes' ;;


### PR DESCRIPTION
I can not deploy with the latest serverless version 4 as it is no longer free, so explicitly using 3 as suggested by others. Also adding a flag for testing a call in bamboo